### PR TITLE
Smoothly handle small, & ignore empty, mpeg-4 atoms. Remove small bit of redundant code

### DIFF
--- a/include/mp4.h
+++ b/include/mp4.h
@@ -74,9 +74,9 @@ typedef struct mp4info {
   char *file;
   Buffer *buf;
   uint64_t file_size; // total file size
-  uint64_t size;      // total size
-  uint8_t  hsize;     // header size
-  uint64_t rsize;     // remaining size
+  uint64_t size;      // total size of box; 0 => remainder of file
+  uint8_t  hsize;     // header size in box
+  uint64_t rsize;     // remaining size in box outside header
   uint64_t audio_offset;
   uint64_t audio_size;
   HV *info;

--- a/src/mp4.c
+++ b/src/mp4.c
@@ -706,7 +706,7 @@ _mp4_read_box(mp4info *mp4)
   DEBUG_TRACE("%s size %llu\n", type, size);
 
   if (size == mp4->hsize) {
-    DEBUG_TRACE("  Ignoring empty box of type %s\n", type);
+    PerlIO_printf(PerlIO_stderr(), "Ignoring empty box of type %s in: %s\n", type, mp4->file);
     return size;
   }
 

--- a/src/mp4.c
+++ b/src/mp4.c
@@ -687,7 +687,16 @@ _mp4_read_box(mp4info *mp4)
     size = buffer_get_int64(mp4->buf);
     mp4->hsize = 16;
   }
-  if (size != 0) { // if (size == 0) // XXX: size extends to end of file
+
+  if (size == 0) { 
+    // XXX: box extends to end of file
+    /*nothing to do*/ ; // rsize=size=0
+  } 
+  else if (size < mp4->hsize) {
+    PerlIO_printf(PerlIO_stderr(), "Invalid box size in: %s\n", mp4->file);
+    return 0;
+  }
+  else {
     // set size of the remainder of the box
     mp4->rsize = size - mp4->hsize;
   } 


### PR DESCRIPTION
Currently Audio::scan will give the following message on mp4 files with an empty mdat atom/box at the end of the file:

`Audio::Scan::scan (64) Warning: Error: Unable to read at least 16 bytes from file (only read 8).`

It tries to read 16 bytes for the atom, and finds there are only 8. As a minimal-size atom is only 8 bytes, the check should be for 8 bytes, not 16. This patch corrects that, and then ignores (with a debug message) any atom which is empty. The warning/error should not appear after this patch.

See https://github.com/Logitech/slimserver/issues/883 for further info and a sample m4a file.
The discussion which led to this discovery [is here](https://forums.slimdevices.com/forum/user-forums/logitech-media-server/1636818-unable-to-read-at-least-16-bytes-from-file-only-read-8). Many thanks to bpa for discovering what it was about these files that led to the problems I've seen.
