### PR TITLE
Add support for audio files of more than 2GB (find_frames function); fixes #13

### DIFF
--- a/Scan.xs
+++ b/Scan.xs
@@ -268,7 +268,7 @@ CODE:
 OUTPUT:
   RETVAL
   
-off_t
+IV
 _find_frame( char *dummy, char *suffix, PerlIO *infile, SV *path, int offset )
 CODE:
 {

--- a/Scan.xs
+++ b/Scan.xs
@@ -56,7 +56,7 @@ typedef struct {
   char*	type;
   int (*get_tags)(PerlIO *infile, char *file, HV *info, HV *tags);
   int (*get_fileinfo)(PerlIO *infile, char *file, HV *tags);
-  int (*find_frame)(PerlIO *infile, char *file, int offset);
+  off_t (*find_frame)(PerlIO *infile, char *file, int offset);
   int (*find_frame_return_info)(PerlIO *infile, char *file, int offset, HV *info);
 } taghandler;
 

--- a/Scan.xs
+++ b/Scan.xs
@@ -268,7 +268,7 @@ CODE:
 OUTPUT:
   RETVAL
   
-int
+off_t
 _find_frame( char *dummy, char *suffix, PerlIO *infile, SV *path, int offset )
 CODE:
 {

--- a/include/asf.h
+++ b/include/asf.h
@@ -218,5 +218,5 @@ void _parse_content_encryption(asfinfo *asf);
 void _parse_extended_content_encryption(asfinfo *asf);
 void _parse_script_command(asfinfo *asf);
 SV *_parse_picture(asfinfo *asf, uint32_t picture_offset);
-int asf_find_frame(PerlIO *infile, char *file, int offset);
+off_t asf_find_frame(PerlIO *infile, char *file, int offset);
 int _timestamp(asfinfo *asf, int offset, int *duration);

--- a/include/mp3.h
+++ b/include/mp3.h
@@ -225,7 +225,7 @@ static int sample_rate_tbl[ ] = {
 
 int get_mp3tags(PerlIO *infile, char *file, HV *info, HV *tags);
 int get_mp3fileinfo(PerlIO *infile, char *file, HV *info);
-int mp3_find_frame(PerlIO *infile, char *file, int offset);
+off_t mp3_find_frame(PerlIO *infile, char *file, int offset);
 
 mp3info * _mp3_parse(PerlIO *infile, char *file, HV *info);
 int _decode_mp3_frame(unsigned char *bptr, struct mp3frame *frame);

--- a/include/mp4.h
+++ b/include/mp4.h
@@ -123,7 +123,7 @@ typedef struct mp4info {
 } mp4info;
 
 static int get_mp4tags(PerlIO *infile, char *file, HV *info, HV *tags);
-int mp4_find_frame(PerlIO *infile, char *file, int offset);
+off_t mp4_find_frame(PerlIO *infile, char *file, int offset);
 int mp4_find_frame_return_info(PerlIO *infile, char *file, int offset, HV *info);
 
 mp4info * _mp4_parse(PerlIO *infile, char *file, HV *info, HV *tags, uint8_t seeking);

--- a/include/ogf.h
+++ b/include/ogf.h
@@ -16,7 +16,7 @@
 
 int get_ogf_metadata(PerlIO *infile, char *file, HV *info, HV *tags);
 int ogf_find_frame_return_info(PerlIO *infile, char *file, int offset, HV *info);
-int ogf_find_frame(PerlIO *infile, char *file, int offset);
+off_t ogf_find_frame(PerlIO *infile, char *file, int offset);
 
 static int _ogf_parse(PerlIO *infile, char *file, HV *info, HV *tags, uint8_t seeking);
-static int _ogf_find_frame(PerlIO *infile, char *file, int offset, HV *info, HV *tags);
+static off_t _ogf_find_frame(PerlIO *infile, char *file, int offset, HV *info, HV *tags);

--- a/include/ogg.h
+++ b/include/ogg.h
@@ -20,6 +20,6 @@
 
 int get_ogg_metadata(PerlIO *infile, char *file, HV *info, HV *tags);
 int _ogg_parse(PerlIO *infile, char *file, HV *info, HV *tags, uint8_t seeking);
-static int ogg_find_frame(PerlIO *infile, char *file, int offset);
+static off_t ogg_find_frame(PerlIO *infile, char *file, int offset);
 void _parse_vorbis_comments(PerlIO *infile, Buffer *vorbis_buf, HV *tags, int has_framing);
 int _ogg_binary_search_sample(PerlIO *infile, char *file, HV *info, uint64_t target_sample);

--- a/include/opus.h
+++ b/include/opus.h
@@ -18,6 +18,6 @@
 
 int get_opus_metadata(PerlIO *infile, char *file, HV *info, HV *tags);
 int _opus_parse(PerlIO *infile, char *file, HV *info, HV *tags, uint8_t seeking);
-static int opus_find_frame(PerlIO *infile, char *file, int offset);
+static off_t opus_find_frame(PerlIO *infile, char *file, int offset);
 void _parse_vorbis_comments(PerlIO *infile, Buffer *vorbis_buf, HV *tags, int has_framing);
 int _opus_binary_search_sample(PerlIO *infile, char *file, HV *info, uint64_t target_sample);

--- a/src/asf.c
+++ b/src/asf.c
@@ -1495,7 +1495,7 @@ _parse_picture(asfinfo *asf, uint32_t picture_offset)
 
 // offset is in ms
 // Based on some code from Rockbox
-int
+off_t
 asf_find_frame(PerlIO *infile, char *file, int time_offset)
 {
   int frame_offset = -1;

--- a/src/flac.c
+++ b/src/flac.c
@@ -270,7 +270,7 @@ out:
 
 // offset is in ms, does sample-accurate seeking, using seektable if available
 // based on libFLAC seek_to_absolute_sample_
-static int
+static off_t
 flac_find_frame(PerlIO *infile, char *file, int offset)
 {
   off_t frame_offset = -1;

--- a/src/mp3.c
+++ b/src/mp3.c
@@ -903,7 +903,7 @@ out:
   return mp3;
 }
 
-int
+off_t
 mp3_find_frame(PerlIO *infile, char *file, int offset)
 {
   Buffer mp3_buf;

--- a/src/mp4.c
+++ b/src/mp4.c
@@ -27,7 +27,7 @@ get_mp4tags(PerlIO *infile, char *file, HV *info, HV *tags)
 }
 
 // wrapper to return just the file offset
-int
+off_t
 mp4_find_frame(PerlIO *infile, char *file, int offset)
 {
   HV *info = newHV();

--- a/src/ogf.c
+++ b/src/ogf.c
@@ -455,7 +455,7 @@ out:
   return frame_offset;
 }
 
-static int
+static off_t
 _ogf_find_frame(PerlIO *infile, char *file, int offset, HV *info, HV *tags)
 {
   int frame_offset = -1;

--- a/src/ogf.c
+++ b/src/ogf.c
@@ -434,7 +434,7 @@ out:
   return err;
 }
 
-int
+off_t
 ogf_find_frame(PerlIO *infile, char *file, int offset)
 {
   HV *info = newHV();

--- a/src/ogg.c
+++ b/src/ogg.c
@@ -500,7 +500,7 @@ _parse_vorbis_comments(PerlIO *infile, Buffer *vorbis_buf, HV *tags, int has_fra
   }
 }
 
-static int
+static off_t
 ogg_find_frame(PerlIO *infile, char *file, int offset)
 {
   int frame_offset = -1;

--- a/src/opus.c
+++ b/src/opus.c
@@ -349,7 +349,7 @@ out:
   return 0;
 }
 
-static int
+static off_t
 opus_find_frame(PerlIO *infile, char *file, int offset)
 {
   int frame_offset = -1;


### PR DESCRIPTION
This patch set changes the return type for the *_find_frame functions in all of the Audio Formats that support it (e.g. flac, ogg, ogf, mp4 etc). We change the type to off_t in C, IV in perl, i.e. 64 bit. The original type was 32 bits integer.

Fixes: https://github.com/LMS-Community/Audio-Scan/issues/13

Before this change, find_frame was returning a negative value when the seek result was pointing to frames that were past the 2GB byte mark in the audio file. This was due to the rollover of the 32 bit integer that was used, unable to accomodate values larger than 2*10^9.

One effect of this issue was that during a library scan, if a multi-track file (e.g. single-flac+cuesheet) was larger than 2GB and there were tracks past the 2GB mark, those tracks get added to the library with a meaningless negative value as starting frame and were not playable in lyrion.

For people using multi-track flac containers, typical Hi-Res 2-channel albums with a total length of more than ~100 minutes were affected by this problem. 

